### PR TITLE
Added support for `email` based authentication

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sanic-beskar"
-version = "2.0.3"
+version = "2.0.4"
 description = "Strong, Simple, (now async!) and Precise security for Sanic APIs"
 authors = ["Rob Dailey <rob@suspected.org>"]
 license = "MIT"


### PR DESCRIPTION
`authenticate()` now takes an optional 'lookup' argument, which specifies if 'username' or 'email' should be used for lookups. Defaults to 'username' for backwards compat.