### PR TITLE
Python 3.12 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sanic-beskar"
-version = "2.2.13"
+version = "2.3.0"
 description = "Strong, Simple, (now async!) and Precise security for Sanic APIs"
 authors = ["Rob Dailey <rob@suspected.org>"]
 license = "MIT"


### PR DESCRIPTION
- Dependancy updates
- Tested versions updated
- Python 3.12 supported (uses a currently beta version of `pendulum`). Closes #54 
