### PR TITLE
Issue #69: Fixed SenderError in register example

### DIFF
--- a/example/register.py
+++ b/example/register.py
@@ -4,6 +4,7 @@ import string
 import sanic_beskar
 from async_sender import Mail  # type: ignore
 from sanic import Sanic, json
+from sanic.response.types import JSONResponse
 from sanic_beskar import Beskar
 from tortoise import fields
 from tortoise.contrib.sanic import register_tortoise
@@ -243,9 +244,9 @@ def create_app() -> Sanic:
             roles="operator",
         )
 
-        await _guard.send_registration_email(email, user=new_user)
+        await _guard.send_registration_email(email, user=new_user, confirmation_sender="you@whatever.com")
         ret = {"message": f"successfully sent registration email to user {new_user.username}"}
-        return (json(ret), 201)
+        return JSONResponse(ret, 201)
 
     @sanic_app.route("/finalize")
     async def finalize(*args):

--- a/sanic_beskar/base.py
+++ b/sanic_beskar/base.py
@@ -1798,17 +1798,14 @@ class Beskar:
             jinja_tmpl = jinja2.Template(template, autoescape=True, enable_async=True)
             notification["message"] = (await jinja_tmpl.render_async(notification)).strip()
 
-            _mail = import_module(self.app.ctx.mail.__module__)
-            msg = _mail.Message(
+            logger.debug(f"Sending email to {email}")
+            notification["result"] = await self.app.ctx.mail.send_message(
                 subject=notification["subject"],
                 to=[notification["email"]],
                 from_address=action_sender,
                 html=notification["message"],
-                reply_to=[action_sender],
+                reply_to=action_sender
             )
-
-            logger.debug(f"Sending email to {email}")
-            notification["result"] = await self.app.ctx.mail.send_message(msg)
 
         return notification
 


### PR DESCRIPTION
A BeskarError is being raised as a result of SenderError in the async_sender library when running the register example; this is because the Message being sent does not have the `to`, `cc` or `bcc` attributes as consequence of being reinitialised.

This was resolved by directly adding the Message arguements to the `self.app.ctx.mail.send_message()` method.

Also:
* Changed the `reply_to` value from a list to a str
* Changed the response on the `/register` endpoint to JSONResponse